### PR TITLE
Fix an issue where the onBlurCapture event caused weird behavior

### DIFF
--- a/frontend/src/components/pages/sign-off/SignOffSearch.tsx
+++ b/frontend/src/components/pages/sign-off/SignOffSearch.tsx
@@ -110,7 +110,11 @@ class SignOffSearch extends Component<
     }
 
     componentDidMount() {
-        this.setState(() => ({ searchQuery: "" }));
+        this.setState(() => ({
+            searchQuery: "",
+            selectedAssignmentSet: null,
+            dropdownOpen: false,
+        }));
         this.props.fetchAssignmentSets(this.props.match.params.cid);
         this.props.fetchAssignmentGroupSetsMapping(this.props.match.params.cid);
     }
@@ -344,15 +348,16 @@ class SignOffSearch extends Component<
                 onSuggestionSelected={(_: any, suggestion: any) => {
                     if (suggestion == null) {
                         return;
+                    } else {
+                        const groupAssignmentSetCombination: GroupAssignmentSetCombination =
+                            suggestion.suggestion;
+                        this.setState({ searchQuery: "" }, () => {
+                            this.pushURL(
+                                groupAssignmentSetCombination.assignmentSet.id,
+                                groupAssignmentSetCombination.id,
+                            );
+                        });
                     }
-                    const groupAssignmentSetCombination: GroupAssignmentSetCombination =
-                        suggestion.suggestion;
-                    this.setState({ searchQuery: "" }, () => {
-                        this.pushURL(
-                            groupAssignmentSetCombination.assignmentSet.id,
-                            groupAssignmentSetCombination.id,
-                        );
-                    });
                 }}
                 inputProps={{
                     autoFocus: true,
@@ -364,7 +369,6 @@ class SignOffSearch extends Component<
                             searchQuery: newValue.newValue,
                         }));
                     },
-                    onBlurCapture: () => this.selectFirstSuggestion(false),
                     onKeyPress: (e) => {
                         if (e.key === "Enter") {
                             this.selectFirstSuggestion(true);
@@ -469,7 +473,6 @@ class SignOffSearch extends Component<
                 sections.push(section);
             }
         });
-
         return sections;
     }
 


### PR DESCRIPTION
So what happened was:

1. Look for a group in any assignment set in the sign-off table search
2. Click on the group and go back to the dashboard
3. Go back to the sign-off table and now look for another group in another assignment set
4. Clicking on that group will result in an `onBlurCapture`, which will overrule (for some reason) the `onSuggestionSelected` event from `AutoSuggest`

The last step caused the first 'hit' to be selected when clicking any other suggestion.

This will now no longer happen, since the `onBlurCapture` event has now just been removed from the `inputProps`. (There was no real reason to have it there anyway)